### PR TITLE
Checking entity is not empty

### DIFF
--- a/src/Context/Initializer/RegistryAwareInitializer.php
+++ b/src/Context/Initializer/RegistryAwareInitializer.php
@@ -24,7 +24,7 @@ class RegistryAwareInitializer implements ContextInitializer
      * @param Registry $registry
      */
     public function __construct(Registry $registry)
-    {\
+    {
         $this->registry = $registry;
     }
 

--- a/src/Context/Initializer/RegistryAwareInitializer.php
+++ b/src/Context/Initializer/RegistryAwareInitializer.php
@@ -24,7 +24,7 @@ class RegistryAwareInitializer implements ContextInitializer
      * @param Registry $registry
      */
     public function __construct(Registry $registry)
-    {
+    {\
         $this->registry = $registry;
     }
 

--- a/src/Registry.php
+++ b/src/Registry.php
@@ -130,7 +130,9 @@ class Registry extends \ArrayObject
 
         $this->persister->beginTransaction();
         foreach ($this as $entity) {
-            $this->persister->remove($entity);
+            if (!empty($entity)) {
+                $this->persister->remove($entity);
+            }
         }
 
         $this->persister->commitTransaction();
@@ -147,7 +149,9 @@ class Registry extends \ArrayObject
 
         $this->persister->beginTransaction();
         foreach ($this as $entity) {
-            $this->persister->persist($entity);
+            if (!empty($entity)){
+                $this->persister->persist($entity);
+            }
         }
 
         $this->persister->commitTransaction();
@@ -165,7 +169,9 @@ class Registry extends \ArrayObject
         $this->checkPersister();
 
         foreach ($this as $key => $entity) {
-            $this[$key] = $this->persister->reload($entity);
+            if (!empty($entity)) {
+                $this[$key] = $this->persister->reload($entity);
+            }
         }
 
         return $this;

--- a/tests/RegistryTest.php
+++ b/tests/RegistryTest.php
@@ -34,6 +34,26 @@ class RegistryTest extends \PHPUnit_Framework_TestCase
         $registry->persist();
     }
 
+
+    public function testPersistNull()
+    {
+        $firstEntity = null;
+
+        $persister = $this->getMock('\eBayEnterprise\Behat\RegistryExtension\Persister');
+        $persister->expects($this->at(0))
+            ->method('beginTransaction');
+
+        $persister->expects($this->never())
+            ->method('persist');
+
+        $persister->expects($this->at(1))
+            ->method('commitTransaction');
+
+        $registry = new Registry($persister);
+        $registry->append($firstEntity);
+        $registry->persist();
+    }
+
     public function testPersistWithoutPersister()
     {
         $this->setExpectedException('InvalidArgumentException');
@@ -78,6 +98,25 @@ class RegistryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array(), $registry->getArrayCopy());
     }
 
+    public function testCleanNull()
+    {
+        $firstEntity = null;
+
+        $persister = $this->getMock('\eBayEnterprise\Behat\RegistryExtension\Persister');
+        $persister->expects($this->at(0))
+            ->method('beginTransaction');
+
+        $persister->expects($this->never())
+            ->method('remove');
+
+        $persister->expects($this->at(1))
+            ->method('commitTransaction');
+
+        $registry = new Registry($persister);
+        $registry->append($firstEntity);
+        $registry->reset();
+    }
+
     public function testReload()
     {
         $oldEntity = new \stdClass();
@@ -94,6 +133,19 @@ class RegistryTest extends \PHPUnit_Framework_TestCase
         $registry->reload();
 
         $this->assertSame($newEntity, $registry->findOne(get_class($oldEntity)));
+    }
+
+    public function testReloadNull()
+    {
+        $oldEntity = null;
+
+        $persister = $this->getMock('\eBayEnterprise\Behat\RegistryExtension\Persister');
+        $persister->expects($this->never())
+            ->method('reload');
+
+        $registry = new Registry($persister);
+        $registry->append($oldEntity);
+        $registry->reload();
     }
 
     public function testMergeWithArray()


### PR DESCRIPTION
For some reason when some cleanup is done the registry leaves null values on it's array and tries to run doctrine functions with these null values, returning an exception. By checking entities are not empty we avoid the issue.
